### PR TITLE
removed guard/guard

### DIFF
--- a/lib/guard/bundler_audit.rb
+++ b/lib/guard/bundler_audit.rb
@@ -1,5 +1,4 @@
 require 'guard'
-require 'guard/guard'
 require 'bundler/audit'
 require 'guard/plugin'
 require 'bundler/audit/scanner'


### PR DESCRIPTION
Currently provides the following error with Guard > 2.8:
>    2:32:02 - ERROR - Error is: cannot load such file -- guard/guard

Per [breaking changes in Guard] (https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0), need to remove guard/guard requirement.